### PR TITLE
add const to ParseError

### DIFF
--- a/INIReader.h
+++ b/INIReader.h
@@ -318,7 +318,7 @@ public:
 
     // Return the result of ini_parse(), i.e., 0 on success, line number of
     // first error on parse error, or -1 on file open error.
-    int ParseError();
+    int ParseError() const;
 
     // Return the list of sections found in ini file
     std::set<std::string> Sections();
@@ -367,7 +367,7 @@ inline INIReader::INIReader(string filename)
     _error = ini_parse(filename.c_str(), ValueHandler, this);
 }
 
-inline int INIReader::ParseError()
+inline int INIReader::ParseError() const
 {
     return _error;
 }


### PR DESCRIPTION
ParseError does not modify the object and should a priori be usable from const methods of objects encapsulating a INIReader object. Therefore ParseError should be const.