### PR TITLE
Fix usage example of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ int main() {
 
     INIReader reader("test.ini");
 
-    if (reader.ParseError() < 0) {
+    if (reader.ParseError() != 0) {
         std::cout << "Can't load 'test.ini'\n";
         return 1;
     }


### PR DESCRIPTION
There is an error in the usage example. The method `ParseError()` returns `-1` if file can't be loaded or line number where parsing error occured. So the right checking that no error occured is `ParseError() != 0`.