### PR TITLE
Add compilers to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,48 @@
 language: c
 sudo: false
+matrix:
+  include:
+    - os: linux
+      compiler: g++-5
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+    - os: linux
+      compiler: g++-6
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+    - os: linux
+      compiler: g++-7
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+    - os: linux
+      compiler: g++-8
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-8
+    - os: linux
+      compiler: g++-9
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-9
 install:
-  - g++ INIReaderTest.cpp -o INIReaderTest.out 
+  - ${TRAVIS_COMPILER} -O2 -Wall INIReaderTest.cpp -o INIReaderTest.out
 script:
   - ./INIReaderTest.out


### PR DESCRIPTION
This is a PR to allow testing with multiple compilers:
* g++ 5
* g++ 6
* g++ 7
* g++ 8
* g++ 9

Currently the test application was only compiled with g++ version 5.4.0 on Travis CI.